### PR TITLE
Updated Chicken Drop Table (Authentic)

### DIFF
--- a/Server/data/configs/drop_tables.json
+++ b/Server/data/configs/drop_tables.json
@@ -2116,19 +2116,25 @@
     "main": [
       {
         "minAmount": "1",
-        "weight": "33.0",
+        "weight": "25.0",
         "id": "0",
         "maxAmount": "1"
       },
       {
-        "minAmount": "1",
-        "weight": "33.0",
+        "minAmount": "5",
+        "weight": "25.0",
         "id": "314",
-        "maxAmount": "6"
+        "maxAmount": "5"
+      },
+      {
+        "minAmount": "10",
+        "weight": "25.0",
+        "id": "314",
+        "maxAmount": "10"
       },
       {
         "minAmount": "15",
-        "weight": "33.0",
+        "weight": "25.0",
         "id": "314",
         "maxAmount": "15"
       }


### PR DESCRIPTION
I got a complaint about feather scarcity and looked into the Chicken's feather drop rate. After checking with the 2009 RS Wiki Revision, I noticed some inconsistencies with the current drop table.

Currently, Chickens drop feathers 66% of the time: 33% to drop 1-6, and 33% to drop 15.

Officially, Chickens should drop either 5, 10, or 15 feathers, according to the 2009 RS Wiki Revision.

I've taken the weights from the OSRS Wiki as a reference, so the drop rate for feathers has been changed to 75%: 25% for 5, 25% for 10, 25% for 15, and 25% for none.